### PR TITLE
feat: replace JSON sidecars with SQLite persistence

### DIFF
--- a/agentsuitelocal/api/state.py
+++ b/agentsuitelocal/api/state.py
@@ -1,4 +1,4 @@
-"""Shared in-memory state and JSON sidecar persistence."""
+"""Shared in-memory state and SQLite persistence."""
 
 from __future__ import annotations
 
@@ -6,8 +6,10 @@ import asyncio
 import collections
 import json
 import math
+import sqlite3
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -25,54 +27,139 @@ _run_cancel_tokens: dict[str, threading.Event] = {}
 # B4: per-run SSE event buffer (last N events per run)
 _run_event_buffers: dict[str, collections.deque] = {}
 
+_DB_FILE = Path.home() / ".agentsuitelocal" / "state.db"
+# Legacy JSON paths — read once during one-time migration, then ignored
 _RUNS_FILE = Path.home() / ".agentsuitelocal" / "runs.json"
 _PIPELINES_FILE = Path.home() / ".agentsuitelocal" / "pipelines.json"
 _MAX_RUNS = 50
 _SSE_BUFFER_SIZE = 100
 
 
-def _load_state() -> None:
-    """Populate _runs and _pipelines from disk on startup. F1: repair running runs."""
-    for path, store in ((_RUNS_FILE, _runs), (_PIPELINES_FILE, _pipelines)):
-        if path.exists():
-            try:
-                data = json.loads(path.read_text())
+@contextmanager
+def _get_conn():
+    """Open a SQLite connection, commit on success, close on exit."""
+    conn = sqlite3.connect(str(_DB_FILE))
+    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _init_db() -> bool:
+    """Create tables if they don't exist. Returns True if the DB was newly created."""
+    _DB_FILE.parent.mkdir(parents=True, exist_ok=True)
+    is_new = not _DB_FILE.exists()
+    with _get_conn() as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS runs (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL,
+                started_at REAL
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS pipelines (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL
+            )
+        """)
+    return is_new
+
+
+def _migrate_from_json() -> None:
+    """One-time migration: import runs.json and pipelines.json into SQLite."""
+    for path, table in ((_RUNS_FILE, "runs"), (_PIPELINES_FILE, "pipelines")):
+        if not path.exists():
+            continue
+        try:
+            data = json.loads(path.read_text())
+            with _get_conn() as conn:
                 for k, v in data.items():
-                    # F1: Crash recovery — running → error with clear message
-                    if v.get("status") == "running":
-                        v["status"] = "error"
-                        v["error"] = "AgentSuiteLocal restarted while this run was in progress."
-                        v["error_message"] = v["error"]
-                        v["finished_at"] = time.time()
-                    # F2: Pipeline orphan repair — pipelines stuck running → error
-                    if store is _pipelines and v.get("status") == "running":
-                        v["status"] = "error"
-                        v["error_message"] = "AgentSuiteLocal restarted during pipeline execution."
-                        v["updated_at"] = time.time()
-                        for step in v.get("steps", []):
-                            if step.get("status") == "running":
-                                step["status"] = "error"
-                    # Migration: scrub any non-finite floats
-                    if v.get("qa_dimensions"):
-                        v["qa_dimensions"] = [
-                            d for d in v["qa_dimensions"]
-                            if isinstance(d.get("score"), int | float) and math.isfinite(float(d["score"]))
-                        ]
-                    store[k] = v
+                    started_at = v.get("started_at", 0)
+                    conn.execute(
+                        f"INSERT OR IGNORE INTO {table} (id, data, started_at) VALUES (?, ?, ?)",  # noqa: S608
+                        (k, json.dumps(v, default=str), started_at),
+                    )
+        except Exception:
+            pass
+
+
+def _load_state() -> None:
+    """Populate _runs and _pipelines from SQLite on startup. F1/F2: repair running records."""
+    is_new = _init_db()
+    if is_new:
+        _migrate_from_json()
+
+    with _get_conn() as conn:
+        for row in conn.execute("SELECT id, data FROM runs"):
+            try:
+                v = json.loads(row[1])
             except Exception:
-                pass
+                continue
+            # F1: Crash recovery — running → error with clear message
+            if v.get("status") == "running":
+                v["status"] = "error"
+                v["error"] = "AgentSuiteLocal restarted while this run was in progress."
+                v["error_message"] = v["error"]
+                v["finished_at"] = time.time()
+            # Migration: scrub any non-finite floats
+            if v.get("qa_dimensions"):
+                v["qa_dimensions"] = [
+                    d for d in v["qa_dimensions"]
+                    if isinstance(d.get("score"), int | float) and math.isfinite(float(d["score"]))
+                ]
+            _runs[v.get("id", row[0])] = v
+
+        for row in conn.execute("SELECT id, data FROM pipelines"):
+            try:
+                v = json.loads(row[1])
+            except Exception:
+                continue
+            # F2: Pipeline orphan repair — pipelines stuck running → error
+            if v.get("status") == "running":
+                v["status"] = "error"
+                v["error_message"] = "AgentSuiteLocal restarted during pipeline execution."
+                v["updated_at"] = time.time()
+                for step in v.get("steps", []):
+                    if step.get("status") == "running":
+                        step["status"] = "error"
+            _pipelines[v.get("id", row[0])] = v
 
 
 def _save_state() -> None:
-    """Persist _runs and _pipelines to disk. Evicts oldest runs beyond _MAX_RUNS."""
+    """Persist _runs and _pipelines to SQLite. Evicts oldest runs beyond _MAX_RUNS."""
     with _state_write_lock:
-        _RUNS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _DB_FILE.parent.mkdir(parents=True, exist_ok=True)
         if len(_runs) > _MAX_RUNS:
             sorted_ids = sorted(_runs, key=lambda r: _runs[r].get("started_at", 0))
             for rid in sorted_ids[: len(_runs) - _MAX_RUNS]:
                 del _runs[rid]
-        _RUNS_FILE.write_text(json.dumps(_runs, indent=2, default=str))
-        _PIPELINES_FILE.write_text(json.dumps(_pipelines, indent=2, default=str))
+
+        with _get_conn() as conn:
+            for run_id, run in _runs.items():
+                conn.execute(
+                    "INSERT OR REPLACE INTO runs (id, data, started_at) VALUES (?, ?, ?)",
+                    (run_id, json.dumps(run, default=str), run.get("started_at", 0)),
+                )
+            # Remove DB rows for evicted runs
+            existing_ids = {row[0] for row in conn.execute("SELECT id FROM runs")}
+            for rid in existing_ids - set(_runs):
+                conn.execute("DELETE FROM runs WHERE id = ?", (rid,))
+
+            for pid, pipeline in _pipelines.items():
+                conn.execute(
+                    "INSERT OR REPLACE INTO pipelines (id, data) VALUES (?, ?)",
+                    (pid, json.dumps(pipeline, default=str)),
+                )
+            # Remove DB rows for deleted pipelines
+            existing_pids = {row[0] for row in conn.execute("SELECT id FROM pipelines")}
+            for pid in existing_pids - set(_pipelines):
+                conn.execute("DELETE FROM pipelines WHERE id = ?", (pid,))
 
 
 _load_state()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -985,24 +985,34 @@ def test_run_timeout_seconds_in_settings():
 
 def test_crash_recovery_sets_running_runs_to_error():
     """load_state must repair running → error on startup (F1)."""
-    from agentsuitelocal.api.state import _load_state, _runs
-    run_id = "test-crash-recovery"
-    _runs[run_id] = {"id": run_id, "status": "running", "agent": "founder", "project": "p",
-                     "goal": "g", "started_at": 0, "events": [], "artifacts": [], "qa_score": None,
-                     "qa_dimensions": []}
-    # Simulate saving and reloading by calling _load_state with patched file
     import json
+    import sqlite3
     import tempfile
     from pathlib import Path
     from unittest.mock import patch
-    tmp = Path(tempfile.mktemp(suffix=".json"))
-    tmp.write_text(json.dumps({run_id: _runs[run_id]}))
+
+    from agentsuitelocal.api.state import _load_state, _runs
+
+    run_id = "test-crash-recovery"
+    run_data = {"id": run_id, "status": "running", "agent": "founder", "project": "p",
+                "goal": "g", "started_at": 0, "events": [], "artifacts": [], "qa_score": None,
+                "qa_dimensions": []}
+
+    # Seed a temp SQLite DB with a "running" run, then reload from it
+    tmp_db = Path(tempfile.mktemp(suffix=".db"))
+    conn = sqlite3.connect(str(tmp_db))
+    conn.execute("CREATE TABLE runs (id TEXT PRIMARY KEY, data TEXT NOT NULL, started_at REAL)")
+    conn.execute("CREATE TABLE pipelines (id TEXT PRIMARY KEY, data TEXT NOT NULL)")
+    conn.execute("INSERT INTO runs VALUES (?, ?, ?)", (run_id, json.dumps(run_data), 0))
+    conn.commit()
+    conn.close()
+
     _runs.clear()
-    with patch("agentsuitelocal.api.state._RUNS_FILE", tmp):
+    with patch("agentsuitelocal.api.state._DB_FILE", tmp_db):
         _load_state()
     assert _runs[run_id]["status"] == "error"
     assert "restarted" in _runs[run_id].get("error", "")
-    tmp.unlink(missing_ok=True)
+    tmp_db.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces `runs.json` + `pipelines.json` with a single SQLite DB at `~/.agentsuitelocal/state.db`
- Schema: `runs(id TEXT PK, data TEXT, started_at REAL)` and `pipelines(id TEXT PK, data TEXT)` — full JSON blob per row, no schema migration needed when dict fields change
- WAL mode for concurrent reads from SSE stream generators
- `_state_write_lock` semantics preserved unchanged
- One-time migration from legacy JSON on first startup (old files left in place)
- `_get_conn()` is a `@contextmanager` that commits, rollbacks on error, and explicitly closes — required on Windows where unclosed handles block file deletion

## What didn't change

- `_runs` and `_pipelines` in-memory dicts: same interface, same locking
- `_load_state()` / `_save_state()` signatures: unchanged
- F1/F2 crash recovery (running → error on startup): same logic
- `_MAX_RUNS` eviction: same behavior, DB rows pruned on save

## Test plan

- [ ] CI passes all 120 backend tests
- [ ] Coverage ≥ 58%
- [ ] Crash recovery test seeds temp SQLite DB directly, asserts repair to `error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)