### PR TITLE
chore: migrate GitHub Actions pins to node24 (v6/v7/v8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,19 @@ on:
     branches: ["main"]
 
 # SHA pins — update via: gh api repos/<owner>/<repo>/git/ref/tags/<tag> --jq '.object.sha'
-# actions/checkout@v4       → 34e114876b0b11c390a56381ad16ebd13914f8d5
-# actions/setup-python@v5   → a26af69be951a213d495a4c3e4e4022e16d87065
-# actions/setup-node@v4     → 49933ea5288caeca8642d1e84afbd3f7d6820020
+# actions/checkout@v6       → de0fac2e4500dabe0009e67214ff5f5447ce83dd
+# actions/setup-python@v6   → a309ff8b426b58ec0e2a45f0f869d46889d02405
+# actions/setup-node@v6     → 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -39,10 +39,10 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -66,10 +66,10 @@ jobs:
     needs: lint
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "24"
           cache: npm
@@ -95,16 +95,16 @@ jobs:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
           cache: pip
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "24"
           cache: npm
@@ -135,10 +135,10 @@ jobs:
     needs: [test, frontend]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -147,7 +147,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ permissions:
   contents: write
 
 # SHA pins — update via: gh api repos/<owner>/<repo>/git/ref/tags/<tag> --jq '.object.sha'
-# actions/checkout@v4               → 34e114876b0b11c390a56381ad16ebd13914f8d5
-# actions/setup-python@v5           → a26af69be951a213d495a4c3e4e4022e16d87065
-# actions/setup-node@v4             → 49933ea5288caeca8642d1e84afbd3f7d6820020
-# actions/upload-artifact@v4        → ea165f8d65b6e75b540449e92b4886f43607fa02
-# actions/download-artifact@v4      → d3f86a106a0bac45b974a628896c90dbdf5c8093
+# actions/checkout@v6               → de0fac2e4500dabe0009e67214ff5f5447ce83dd
+# actions/setup-python@v6           → a309ff8b426b58ec0e2a45f0f869d46889d02405
+# actions/setup-node@v6             → 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+# actions/upload-artifact@v7        → 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+# actions/download-artifact@v8      → 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
 # softprops/action-gh-release@v2    → 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
 
 jobs:
@@ -56,15 +56,15 @@ jobs:
     needs: verify-ci
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "24"
           cache: npm
@@ -108,7 +108,7 @@ jobs:
           iscc /DMYAPPVERSION=$ver installer/AgentSuiteLocal.iss
 
       - name: Upload Windows installer
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: AgentSuiteLocal-Windows-Setup
           path: dist/AgentSuiteLocal-*-setup.exe
@@ -120,15 +120,15 @@ jobs:
     needs: verify-ci
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 
       - name: Set up Node.js 24
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "24"
           cache: npm
@@ -163,7 +163,7 @@ jobs:
             dist/AgentSuiteLocal-${{ github.ref_name }}.dmg
 
       - name: Upload macOS DMG
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: AgentSuiteLocal-macOS
           path: dist/AgentSuiteLocal-*.dmg
@@ -175,16 +175,16 @@ jobs:
     needs: [build-windows, build-macos]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Download Windows artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: AgentSuiteLocal-Windows-Setup
           path: release-artifacts
 
       - name: Download macOS artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: AgentSuiteLocal-macOS
           path: release-artifacts


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v6 (node24, SHA `de0fac2e`)
- `actions/setup-python` v5 → v6 (node24, SHA `a309ff8b`)
- `actions/setup-node` v4 → v6 (node24, SHA `48b55a01`)
- `actions/upload-artifact` v4 → v7 (node24, SHA `043fb46d`) — release.yml only
- `actions/download-artifact` v4 → v8 (node24, SHA `3e5f45b2`) — release.yml only

GitHub deprecated node20-based actions; runners warn from 2026-05-01 and will error after 2026-06-02. All five SHAs verified against upstream tag releases before pinning.

## Test plan

- [ ] Lint
- [ ] Test 3.11
- [ ] Test 3.12
- [ ] Frontend
- [ ] macOS build (skipped on PR — triggers on main/tags only)
- [ ] Playwright E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)