### PR TITLE
ci: cut Actions burn — concurrency, dual-trigger drop, weekly real-e2e cron, 3.12-only on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,18 @@
 name: CI
 
+# Trigger profile: PR validation only on main. Direct pushes to main go
+# through PRs; release/** branches use the release.yml workflow. Dropping
+# the duplicate `push: branches: [main]` saves a full CI run per merge
+# (was running once on PR + once on post-merge push).
 on:
-  push:
-    branches: ["main", "release/**"]
   pull_request:
     branches: ["main"]
+  push:
+    branches: ["release/**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # SHA pins — update via: gh api repos/<owner>/<repo>/git/ref/tags/<tag> --jq '.object.sha'
 # actions/checkout@v6       → de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -44,7 +52,11 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        # PRs: 3.12 only (production target). Cross-version regression coverage
+        # against 3.11 still gates on release/** push (see release.yml + the
+        # `if:` below). Was matrix: ["3.11", "3.12"] — doubled CI minutes on
+        # every PR without catching anything PRs were actually breaking.
+        python-version: ${{ github.event_name == 'pull_request' && fromJson('["3.12"]') || fromJson('["3.11", "3.12"]') }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6

--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -18,8 +18,12 @@ name: real-e2e
 
 on:
   schedule:
-    # 04:00 UTC daily — quiet hours for most contributors, hot cache.
-    - cron: "0 4 * * *"
+    # Sundays 04:00 UTC — weekly drift catcher. Daily cron was burning
+    # ~1,300 Linux-equivalent minutes per month on a 2,000-min free tier
+    # (45-50 min/run × 30 runs). Weekly catches drift between manual
+    # CI runs while staying inside the budget. Tag + labeled-PR triggers
+    # are unchanged, so the release-gate path is fully preserved.
+    - cron: "0 4 * * 0"
   push:
     tags:
       - "v*"
@@ -30,6 +34,10 @@ on:
     # add their own opt-in trigger if needed.
   pull_request:
     types: [labeled, opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   real-e2e:


### PR DESCRIPTION
## Summary

AgentSuiteLocal burned 4,957 of May 2026's ~7,400 Linux-equivalent Actions minutes — top spender on Scott's scottconverse account, which hit the 2,000 free-tier cap. Full audit and the rationale for each fix in `handoff-to-codex-2026-05-13-civiccast-ci-budget-fixes.md` at the workspace root.

Changes:

1. **`ci.yml`** — drop `push: branches: ["main"]`. Keep `pull_request:` on main plus `push: branches: ["release/**"]` (release branches have no PR equivalent). Was running CI twice per merge (once on PR, once on post-merge push).
2. **`ci.yml`** — add `concurrency: cancel-in-progress: true`. May 8 release week showed 15+ CI runs in one hour because pushes stacked.
3. **`ci.yml`** — Python matrix collapses `[3.11, 3.12]` → `[3.12]` on PR. Full matrix still runs on `release/**` push.
4. **`real-e2e.yml`** — daily cron → weekly Sunday cron. 45–50 min wall-clock per run × 30 runs/month ≈ 1,400 Linux-equiv min just on the cron. Tag + labeled-PR triggers unchanged.
5. **`real-e2e.yml`** — add `concurrency: cancel-in-progress: true`.

`release.yml` intentionally NOT given a `concurrency:` block — tag-push workflows that produce artifacts shouldn't be cancellable mid-build.

## Estimated savings

~2,400 Linux-equiv min/mo from this PR alone (dual-trigger ~500, daily→weekly ~1,300, matrix ~500, concurrency cancel ~100).

## 5-lens self-audit

- **Engineering:** 3/3 YAMLs validated via `python yaml.safe_load`. Matrix conditional uses standard `${{ ... && fromJson(A) || fromJson(B) }}` pattern.
- **UX:** N/A (CI infra).
- **Tests:** `yaml.safe_load` passes. This PR's CI run exercises the new shape live including the matrix conditional.
- **Docs:** inline comments updated in both files explaining the trigger change and the budget motivation.
- **QA:** cross-file — ci.yml + real-e2e.yml both have concurrency. release.yml intentionally omitted (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)