### PR TITLE
chore(ci): migrate Linux jobs to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
@@ -40,7 +40,7 @@ jobs:
 
   test:
     name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     needs: lint
     strategy:
       matrix:
@@ -70,7 +70,7 @@ jobs:
 
   frontend:
     name: Frontend (build + test)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     needs: lint
 
     steps:
@@ -272,7 +272,7 @@ jobs:
     # Playwright E2E coverage before it merges. Remove the push branch
     # filter after release/v0.9.0 merges to main.
     name: Playwright E2E
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     if: |
       (github.event_name == 'pull_request' && github.base_ref == 'main') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/release/v0.9.0')

--- a/.github/workflows/real-e2e.yml
+++ b/.github/workflows/real-e2e.yml
@@ -34,8 +34,7 @@ on:
 jobs:
   real-e2e:
     name: Real-model agent E2E
-    runs-on: ubuntu-latest
-
+    runs-on: [self-hosted, linux, x64]
     # Skip pull_request events unless the `run-real-e2e` label is present.
     # cron + tag pushes always run.
     if: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
   # Tags can be pushed against any commit; this gate ensures only green commits ship.
   verify-ci:
     name: Verify CI passed on tagged commit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
@@ -187,7 +187,7 @@ jobs:
 
   release:
     name: Create GitHub release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     needs: [build-windows, build-macos]
 
     steps:


### PR DESCRIPTION
Migrates Linux jobs to runs-on: [self-hosted, linux, x64], targeting the new self-hosted runner registered to this repo (`nvideablackwell-AgentSuiteLocal-2404`). Windows-latest / macos-latest jobs preserved (no self-hosted runner for those OSes).

Runner host: WSL Ubuntu 24.04 LTS on new-box (NvideaBlackwell, RTX 5070).

Pattern follows [CivicSuite/civicsuite#133](https://github.com/CivicSuite/civicsuite/pull/133) (merged a9bb54a, full CI green on self-hosted).